### PR TITLE
Skip Docker test when Docker is not available

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
 */
 buildPlugin(
   forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
-  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  useContainerAgent: false, // Need testcontainer in EddsaTest
   configurations: [
     [platform: 'linux', jdk: 21],
     [platform: 'windows', jdk: 17],


### PR DESCRIPTION
## Skip Docker test when Docker is not available

Use a conditional check for Docker during test initialization so that the latest plugin update can be included in the plugin bill of materials.  Fixes Windows test failure on the master branch.

Similar to the technique used in docker-plugin and elsewhere so that the tests do not fail when Docker is unavailable.

* https://github.com/jenkinsci/eddsa-api-plugin/commit/dcf1d647a934603bb5bf0611684768055853b3a0#r153984874
* https://github.com/jenkinsci/bom/pull/4739#pullrequestreview-2699468137

### Testing done

Confirmed the tests pass on Ubuntu 22.04 with Java 21 and Docker available both before and after this change.

Confirmed EddsaTest fails before this change on RHEL 8 with Java 21 and no Docker available.

Confirmed EddsaTest passes after this change on RHEL 8 with Java 21 and no Docker available.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
