### PR TITLE
Migrate tests to JUnit5

### DIFF
--- a/src/test/java/io/jenkins/plugins/eddsa_api/FIPSComplianceCheckTest.java
+++ b/src/test/java/io/jenkins/plugins/eddsa_api/FIPSComplianceCheckTest.java
@@ -25,14 +25,14 @@ public class FIPSComplianceCheckTest {
     }
 
     @Test
-    public void testStartupFips() throws Throwable {
+    public void testStartupFips() {
         rjr.javaOptions("-Xmx128M", "-Djenkins.security.FIPS140.COMPLIANCE=true");
-        JenkinsStartupException jse = assertThrows(JenkinsStartupException.class, () -> {
-            rjr.then(r -> {
-                Jenkins.get().getPluginManager().uberClassLoader.loadClass("net.i2p.crypto.eddsa.EdDSAEngine");
-                fail("should not get here!");
-            });
-        });
+        JenkinsStartupException jse = assertThrows(
+                JenkinsStartupException.class,
+                () -> rjr.then(r -> {
+                    Jenkins.get().getPluginManager().uberClassLoader.loadClass("net.i2p.crypto.eddsa.EdDSAEngine");
+                    fail("should not get here!");
+                }));
         assertThat(
                 jse.getMessage(),
                 containsString(

--- a/src/test/java/io/jenkins/plugins/eddsa_api/security3404/Security3404Test.java
+++ b/src/test/java/io/jenkins/plugins/eddsa_api/security3404/Security3404Test.java
@@ -4,60 +4,48 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
-import java.util.List;
+import java.util.stream.Stream;
 import net.i2p.crypto.eddsa.EdDSAEngine;
 import net.i2p.crypto.eddsa.EdDSAPublicKey;
 import net.i2p.crypto.eddsa.Utils;
 import net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable;
 import net.i2p.crypto.eddsa.spec.EdDSAParameterSpec;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
-public class Security3404Test {
-    private final String messageHex;
-    private final String publicKeyHex;
-    private final String signatureHex;
+class Security3404Test {
 
     private static final EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
 
-    @Parameterized.Parameters
-    public static List<List<String>> parameters() {
+    static Stream<Arguments> parameters() {
         // See https://eprint.iacr.org/2020/1244.pdf Table 6 c), as well as Section 5.1 for an explanation that these
         // signatures are supposed to fail to ensure SUF-CMA property
-        return List.of(
-                List.of(
+        return Stream.of(
+                Arguments.arguments(
                         "85e241a07d148b41e47d62c63f830dc7a6851a0b1f33ae4bb2f507fb6cffec40",
                         "442aad9f089ad9e14647b1ef9099a1ff4798d78589e66f28eca69c11f582a623",
                         "e96f66be976d82e60150baecff9906684aebb1ef181f67a7189ac78ea23b6c0e547f7690a0e2ddcd04d87dbc3490dc19b3b3052f7ff0538cb68afb369ba3a514"),
-                List.of(
+                Arguments.arguments(
                         "85e241a07d148b41e47d62c63f830dc7a6851a0b1f33ae4bb2f507fb6cffec40",
                         "442aad9f089ad9e14647b1ef9099a1ff4798d78589e66f28eca69c11f582a623",
                         "8ce5b96c8f26d0ab6c47958c9e68b937104cd36e13c33566acd2fe8d38aa19427e71f98a473474f2f13f06f97c20d58cc3f54b8bd0d272f42b695dd7e89a8c22"));
     }
 
-    @Test
-    public void testCases5And6() throws NoSuchAlgorithmException {
-        assertThat(verify_i2p(), is(false));
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void testCases5And6(String messageHex, String publicKeyHex, String signatureHex) {
+        assertThat(verify_i2p(messageHex, publicKeyHex, signatureHex), is(false));
     }
-
-    public Security3404Test(List<String> parameters) {
-        messageHex = parameters.get(0);
-        publicKeyHex = parameters.get(1);
-        signatureHex = parameters.get(2);
-    }
-
     /**
      * Return EdDSAPublicKey object from the hex representation of the compressed Edwards public key point.
      **/
     // Code used under Apache 2.0 license from
     // https://github.com/novifinancial/ed25519-speccheck/blob/main/scripts/ed25519-java/src/main/java/Ed25519TestCase.java
-    private EdDSAPublicKey decodePublicKey() throws InvalidKeySpecException {
-        byte[] pk = Utils.hexToBytes(this.publicKeyHex);
+    private EdDSAPublicKey decodePublicKey(String publicKeyHex) throws InvalidKeySpecException {
+        byte[] pk = Utils.hexToBytes(publicKeyHex);
         byte[] x509pk = EncodingUtils.compressedEd25519PublicKeyToX509(pk);
         X509EncodedKeySpec encoded = new X509EncodedKeySpec(x509pk);
         return new EdDSAPublicKey(encoded);
@@ -68,11 +56,11 @@ public class Security3404Test {
      **/
     // Code used under Apache 2.0 license from
     // https://github.com/novifinancial/ed25519-speccheck/blob/main/scripts/ed25519-java/src/main/java/Ed25519TestCase.java
-    public boolean verify_i2p() {
+    public boolean verify_i2p(String messageHex, String publicKeyHex, String signatureHex) {
         try {
-            EdDSAPublicKey publicKey = decodePublicKey();
-            byte[] messageBytes = Utils.hexToBytes(this.messageHex);
-            byte[] signatureBytes = Utils.hexToBytes(this.signatureHex);
+            EdDSAPublicKey publicKey = decodePublicKey(publicKeyHex);
+            byte[] messageBytes = Utils.hexToBytes(messageHex);
+            byte[] signatureBytes = Utils.hexToBytes(signatureHex);
             EdDSAEngine sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
             sgr.initVerify(publicKey);
             return sgr.verifyOneShot(messageBytes, signatureBytes);

--- a/src/test/java/net/i2p/crypto/eddsa/Ed25519TestVectors.java
+++ b/src/test/java/net/i2p/crypto/eddsa/Ed25519TestVectors.java
@@ -41,7 +41,7 @@ public class Ed25519TestVectors {
     public static Collection<TestTuple> testCases = getTestData("test.data");
 
     public static Collection<TestTuple> getTestData(String fileName) {
-        List<TestTuple> testCases = new ArrayList<TestTuple>();
+        List<TestTuple> testCases = new ArrayList<>();
         BufferedReader file = null;
         try {
             InputStream is = Ed25519TestVectors.class.getResourceAsStream(fileName);

--- a/src/test/java/net/i2p/crypto/eddsa/EdDSAEngineTest.java
+++ b/src/test/java/net/i2p/crypto/eddsa/EdDSAEngineTest.java
@@ -11,12 +11,14 @@
  */
 package net.i2p.crypto.eddsa;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.InvocationTargetException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -26,9 +28,8 @@ import net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable;
 import net.i2p.crypto.eddsa.spec.EdDSAParameterSpec;
 import net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec;
 import net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
+
 // import sun.security.util.DerValue;
 // import sun.security.x509.X509Key;
 
@@ -36,19 +37,16 @@ import org.junit.rules.ExpectedException;
  * @author str4d
  *
  */
-public class EdDSAEngineTest {
+class EdDSAEngineTest {
     static final byte[] TEST_SEED =
             Utils.hexToBytes("0000000000000000000000000000000000000000000000000000000000000000");
     static final byte[] TEST_PK = Utils.hexToBytes("3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29");
-    static final byte[] TEST_MSG = "This is a secret message".getBytes(Charset.forName("UTF-8"));
+    static final byte[] TEST_MSG = "This is a secret message".getBytes(StandardCharsets.UTF_8);
     static final byte[] TEST_MSG_SIG = Utils.hexToBytes(
             "94825896c7075c31bcb81f06dba2bdcd9dcf16e79288d4b9f87c248215c8468d475f429f3de3b4a2cf67fe17077ae19686020364d6d4fa7a0174bab4a123ba0f");
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
     @Test
-    public void testSign() throws Exception {
+    void testSign() throws Exception {
         EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         // Signature sgr = Signature.getInstance("EdDSA", "I2P");
         Signature sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
@@ -65,7 +63,7 @@ public class EdDSAEngineTest {
     }
 
     @Test
-    public void testVerify() throws Exception {
+    void testVerify() throws Exception {
         EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         // Signature sgr = Signature.getInstance("EdDSA", "I2P");
         Signature sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
@@ -84,7 +82,8 @@ public class EdDSAEngineTest {
      * Checks that a wrong-length signature throws an IAE.
      */
     @Test
-    public void testVerifyWrongSigLength() throws Exception {
+    void testVerifyWrongSigLength() throws Exception {
+
         EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         // Signature sgr = Signature.getInstance("EdDSA", "I2P");
         Signature sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
@@ -93,14 +92,12 @@ public class EdDSAEngineTest {
         sgr.initVerify(vKey);
 
         sgr.update(TEST_MSG);
-
-        exception.expect(SignatureException.class);
-        exception.expectMessage("signature length is wrong");
-        sgr.verify(new byte[] {0});
+        SignatureException exception = assertThrows(SignatureException.class, () -> sgr.verify(new byte[] {0}));
+        assertTrue(exception.getMessage().contains("signature length is wrong"));
     }
 
     @Test
-    public void testSignResetsForReuse() throws Exception {
+    void testSignResetsForReuse() throws Exception {
         EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         Signature sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
         EdDSAPrivateKeySpec privKey = new EdDSAPrivateKeySpec(TEST_SEED, spec);
@@ -117,7 +114,7 @@ public class EdDSAEngineTest {
     }
 
     @Test
-    public void testVerifyResetsForReuse() throws Exception {
+    void testVerifyResetsForReuse() throws Exception {
         EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         Signature sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
         EdDSAPublicKeySpec pubKey = new EdDSAPublicKeySpec(TEST_PK, spec);
@@ -134,7 +131,7 @@ public class EdDSAEngineTest {
     }
 
     @Test
-    public void testSignOneShotMode() throws Exception {
+    void testSignOneShotMode() throws Exception {
         EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         Signature sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
         EdDSAPrivateKeySpec privKey = new EdDSAPrivateKeySpec(TEST_SEED, spec);
@@ -148,7 +145,7 @@ public class EdDSAEngineTest {
     }
 
     @Test
-    public void testVerifyOneShotMode() throws Exception {
+    void testVerifyOneShotMode() throws Exception {
         EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         Signature sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
         EdDSAPublicKeySpec pubKey = new EdDSAPublicKeySpec(TEST_PK, spec);
@@ -162,7 +159,7 @@ public class EdDSAEngineTest {
     }
 
     @Test
-    public void testSignOneShotModeMultipleUpdates() throws Exception {
+    void testSignOneShotModeMultipleUpdates() throws Exception {
         EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         Signature sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
         EdDSAPrivateKeySpec privKey = new EdDSAPrivateKeySpec(TEST_SEED, spec);
@@ -171,14 +168,12 @@ public class EdDSAEngineTest {
         sgr.setParameter(EdDSAEngine.ONE_SHOT_MODE);
 
         sgr.update(TEST_MSG);
-
-        exception.expect(SignatureException.class);
-        exception.expectMessage("update() already called");
-        sgr.update(TEST_MSG);
+        SignatureException exception = assertThrows(SignatureException.class, () -> sgr.update(TEST_MSG));
+        assertTrue(exception.getMessage().contains("update() already called"));
     }
 
     @Test
-    public void testVerifyOneShotModeMultipleUpdates() throws Exception {
+    void testVerifyOneShotModeMultipleUpdates() throws Exception {
         EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         EdDSAPublicKeySpec pubKey = new EdDSAPublicKeySpec(TEST_PK, spec);
         Signature sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
@@ -187,14 +182,12 @@ public class EdDSAEngineTest {
         sgr.setParameter(EdDSAEngine.ONE_SHOT_MODE);
 
         sgr.update(TEST_MSG);
-
-        exception.expect(SignatureException.class);
-        exception.expectMessage("update() already called");
-        sgr.update(TEST_MSG);
+        SignatureException exception = assertThrows(SignatureException.class, () -> sgr.update(TEST_MSG));
+        assertTrue(exception.getMessage().contains("update() already called"));
     }
 
     @Test
-    public void testSignOneShot() throws Exception {
+    void testSignOneShot() throws Exception {
         EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         EdDSAPrivateKeySpec privKey = new EdDSAPrivateKeySpec(TEST_SEED, spec);
         EdDSAEngine sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
@@ -205,7 +198,7 @@ public class EdDSAEngineTest {
     }
 
     @Test
-    public void testVerifyOneShot() throws Exception {
+    void testVerifyOneShot() throws Exception {
         EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         EdDSAPublicKeySpec pubKey = new EdDSAPublicKeySpec(TEST_PK, spec);
         EdDSAEngine sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
@@ -216,7 +209,7 @@ public class EdDSAEngineTest {
     }
 
     @Test
-    public void testVerifyX509PublicKeyInfo() throws Exception {
+    void testVerifyX509PublicKeyInfo() throws Exception {
         EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName("Ed25519");
         Signature sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
         for (Ed25519TestVectors.TestTuple testCase : Ed25519TestVectors.testCases) {

--- a/src/test/java/net/i2p/crypto/eddsa/EdDSAPrivateKeyTest.java
+++ b/src/test/java/net/i2p/crypto/eddsa/EdDSAPrivateKeyTest.java
@@ -11,18 +11,18 @@
  */
 package net.i2p.crypto.eddsa;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.security.spec.PKCS8EncodedKeySpec;
 import net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author str4d
  *
  */
-public class EdDSAPrivateKeyTest {
+class EdDSAPrivateKeyTest {
     /**
      * The example private key MC4CAQAwBQYDK2VwBCIEINTuctv5E1hK1bbY8fdp+K06/nwoy/HU++CXqI9EdVhC
      * from https://tools.ietf.org/html/draft-ietf-curdle-pkix-04#section-10.3
@@ -36,7 +36,7 @@ public class EdDSAPrivateKeyTest {
             "302f020100300806032b65640a01010420d4ee72dbf913584ad5b6d8f1f769f8ad3afe7c28cbf1d4fbe097a88f44755842");
 
     @Test
-    public void testDecodeAndEncode() throws Exception {
+    void testDecodeAndEncode() throws Exception {
         // Decode
         PKCS8EncodedKeySpec encoded = new PKCS8EncodedKeySpec(TEST_PRIVKEY);
         EdDSAPrivateKey keyIn = new EdDSAPrivateKey(encoded);
@@ -51,7 +51,7 @@ public class EdDSAPrivateKeyTest {
     }
 
     @Test
-    public void testDecodeWithNullAndEncode() throws Exception {
+    void testDecodeWithNullAndEncode() throws Exception {
         // Decode
         PKCS8EncodedKeySpec encoded = new PKCS8EncodedKeySpec(TEST_PRIVKEY_NULL_PARAMS);
         EdDSAPrivateKey keyIn = new EdDSAPrivateKey(encoded);
@@ -66,7 +66,7 @@ public class EdDSAPrivateKeyTest {
     }
 
     @Test
-    public void testReEncodeOldEncoding() throws Exception {
+    void testReEncodeOldEncoding() throws Exception {
         // Decode
         PKCS8EncodedKeySpec encoded = new PKCS8EncodedKeySpec(TEST_PRIVKEY_OLD);
         EdDSAPrivateKey keyIn = new EdDSAPrivateKey(encoded);

--- a/src/test/java/net/i2p/crypto/eddsa/EdDSAPublicKeyTest.java
+++ b/src/test/java/net/i2p/crypto/eddsa/EdDSAPublicKeyTest.java
@@ -11,18 +11,18 @@
  */
 package net.i2p.crypto.eddsa;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.security.spec.X509EncodedKeySpec;
 import net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author str4d
  *
  */
-public class EdDSAPublicKeyTest {
+class EdDSAPublicKeyTest {
     /**
      * The example public key MCowBQYDK2VwAyEAGb9ECWmEzf6FQbrBZ9w7lshQhqowtrbLDFw4rXAxZuE=
      * from https://tools.ietf.org/html/draft-ietf-curdle-pkix-04#section-10.1
@@ -36,7 +36,7 @@ public class EdDSAPublicKeyTest {
             "302d300806032b65640a010103210019bf44096984cdfe8541bac167dc3b96c85086aa30b6b6cb0c5c38ad703166e1");
 
     @Test
-    public void testDecodeAndEncode() throws Exception {
+    void testDecodeAndEncode() throws Exception {
         // Decode
         X509EncodedKeySpec encoded = new X509EncodedKeySpec(TEST_PUBKEY);
         EdDSAPublicKey keyIn = new EdDSAPublicKey(encoded);
@@ -50,7 +50,7 @@ public class EdDSAPublicKeyTest {
     }
 
     @Test
-    public void testDecodeWithNullAndEncode() throws Exception {
+    void testDecodeWithNullAndEncode() throws Exception {
         // Decode
         X509EncodedKeySpec encoded = new X509EncodedKeySpec(TEST_PUBKEY_NULL_PARAMS);
         EdDSAPublicKey keyIn = new EdDSAPublicKey(encoded);
@@ -64,7 +64,7 @@ public class EdDSAPublicKeyTest {
     }
 
     @Test
-    public void testReEncodeOldEncoding() throws Exception {
+    void testReEncodeOldEncoding() throws Exception {
         // Decode
         X509EncodedKeySpec encoded = new X509EncodedKeySpec(TEST_PUBKEY_OLD);
         EdDSAPublicKey keyIn = new EdDSAPublicKey(encoded);

--- a/src/test/java/net/i2p/crypto/eddsa/EdDSASecurityProviderTest.java
+++ b/src/test/java/net/i2p/crypto/eddsa/EdDSASecurityProviderTest.java
@@ -11,26 +11,23 @@
  */
 package net.i2p.crypto.eddsa;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.security.KeyFactory;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchProviderException;
 import java.security.Security;
 import java.security.Signature;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author str4d
  *
  */
-public class EdDSASecurityProviderTest {
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
+class EdDSASecurityProviderTest {
 
     @Test
-    public void canGetInstancesWhenProviderIsPresent() throws Exception {
+    void canGetInstancesWhenProviderIsPresent() throws Exception {
         Security.addProvider(new EdDSASecurityProvider());
 
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EdDSA", "EdDSA");
@@ -41,8 +38,9 @@ public class EdDSASecurityProviderTest {
     }
 
     @Test
-    public void cannotGetInstancesWhenProviderIsNotPresent() throws Exception {
-        exception.expect(NoSuchProviderException.class);
-        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EdDSA", "EdDSA");
+    void cannotGetInstancesWhenProviderIsNotPresent() {
+        assertThrows(NoSuchProviderException.class, () -> {
+            KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EdDSA", "EdDSA");
+        });
     }
 }

--- a/src/test/java/net/i2p/crypto/eddsa/UtilsTest.java
+++ b/src/test/java/net/i2p/crypto/eddsa/UtilsTest.java
@@ -11,19 +11,19 @@
  */
 package net.i2p.crypto.eddsa;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.security.SecureRandom;
-import org.hamcrest.core.IsEqual;
-import org.junit.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author str4d
  * additional test by the NEM project team.
  *
  */
-public class UtilsTest {
+class UtilsTest {
     private static final String hex1 = "3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29";
     private static final String hex2 = "47a3f5b71494bcd961f3a4e859a238d6eaf8e648746d2f56a89b5e236f98d45f";
     private static final String hex3 = "5fd396e4a2b5dc9078f57e3ab5a87c28fd128e5f78cc4a97f4122dc45f6e4bb9";
@@ -44,7 +44,7 @@ public class UtilsTest {
      * Test method for {@link Utils#equal(int, int)}.
      */
     @Test
-    public void testIntEqual() {
+    void testIntEqual() {
         assertThat(Utils.equal(0, 0), is(1));
         assertThat(Utils.equal(1, 1), is(1));
         assertThat(Utils.equal(1, 0), is(0));
@@ -56,19 +56,19 @@ public class UtilsTest {
     }
 
     @Test
-    public void equalsReturnsOneForEqualByteArrays() {
+    void equalsReturnsOneForEqualByteArrays() {
         final SecureRandom random = new SecureRandom();
         final byte[] bytes1 = new byte[32];
         final byte[] bytes2 = new byte[32];
         for (int i = 0; i < 100; i++) {
             random.nextBytes(bytes1);
             System.arraycopy(bytes1, 0, bytes2, 0, 32);
-            Assert.assertThat(Utils.equal(bytes1, bytes2), IsEqual.equalTo(1));
+            assertThat(Utils.equal(bytes1, bytes2), equalTo(1));
         }
     }
 
     @Test
-    public void equalsReturnsZeroForUnequalByteArrays() {
+    void equalsReturnsZeroForUnequalByteArrays() {
         final SecureRandom random = new SecureRandom();
         final byte[] bytes1 = new byte[32];
         final byte[] bytes2 = new byte[32];
@@ -76,7 +76,7 @@ public class UtilsTest {
         for (int i = 0; i < 32; i++) {
             System.arraycopy(bytes1, 0, bytes2, 0, 32);
             bytes2[i] = (byte) (bytes2[i] ^ 0xff);
-            Assert.assertThat(Utils.equal(bytes1, bytes2), IsEqual.equalTo(0));
+            assertThat(Utils.equal(bytes1, bytes2), equalTo(0));
         }
     }
 
@@ -84,7 +84,7 @@ public class UtilsTest {
      * Test method for {@link Utils#equal(byte[], byte[])}.
      */
     @Test
-    public void testByteArrayEqual() {
+    void testByteArrayEqual() {
         byte[] zero = new byte[32];
         byte[] one = new byte[32];
         one[0] = 1;
@@ -99,7 +99,7 @@ public class UtilsTest {
      * Test method for {@link Utils#negative(int)}.
      */
     @Test
-    public void testNegative() {
+    void testNegative() {
         assertThat(Utils.negative(0), is(0));
         assertThat(Utils.negative(1), is(0));
         assertThat(Utils.negative(-1), is(1));
@@ -113,7 +113,7 @@ public class UtilsTest {
      * Test method for {@link Utils#bit(byte[], int)}.
      */
     @Test
-    public void testBit() {
+    void testBit() {
         assertThat(Utils.bit(new byte[] {0}, 0), is(0));
         assertThat(Utils.bit(new byte[] {8}, 3), is(1));
         assertThat(Utils.bit(new byte[] {1, 2, 3}, 9), is(1));
@@ -122,16 +122,16 @@ public class UtilsTest {
     }
 
     @Test
-    public void hexToBytesReturnsCorrectByteArray() {
-        Assert.assertThat(Utils.hexToBytes(hex1), IsEqual.equalTo(bytes1));
-        Assert.assertThat(Utils.hexToBytes(hex2), IsEqual.equalTo(bytes2));
-        Assert.assertThat(Utils.hexToBytes(hex3), IsEqual.equalTo(bytes3));
+    void hexToBytesReturnsCorrectByteArray() {
+        assertThat(Utils.hexToBytes(hex1), equalTo(bytes1));
+        assertThat(Utils.hexToBytes(hex2), equalTo(bytes2));
+        assertThat(Utils.hexToBytes(hex3), equalTo(bytes3));
     }
 
     @Test
-    public void bytesToHexReturnsCorrectHexString() {
-        Assert.assertThat(Utils.bytesToHex(bytes1), IsEqual.equalTo(hex1));
-        Assert.assertThat(Utils.bytesToHex(bytes2), IsEqual.equalTo(hex2));
-        Assert.assertThat(Utils.bytesToHex(bytes3), IsEqual.equalTo(hex3));
+    void bytesToHexReturnsCorrectHexString() {
+        assertThat(Utils.bytesToHex(bytes1), equalTo(hex1));
+        assertThat(Utils.bytesToHex(bytes2), equalTo(hex2));
+        assertThat(Utils.bytesToHex(bytes3), equalTo(hex3));
     }
 }

--- a/src/test/java/net/i2p/crypto/eddsa/math/AbstractFieldElementTest.java
+++ b/src/test/java/net/i2p/crypto/eddsa/math/AbstractFieldElementTest.java
@@ -11,9 +11,12 @@
  */
 package net.i2p.crypto.eddsa.math;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
 import java.math.BigInteger;
 import org.hamcrest.core.*;
-import org.junit.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests rely on the BigInteger class.
@@ -35,21 +38,21 @@ public abstract class AbstractFieldElementTest {
     protected abstract FieldElement getNonZeroFieldElement();
 
     @Test
-    public void isNonZeroReturnsFalseIfFieldElementIsZero() {
+    void isNonZeroReturnsFalseIfFieldElementIsZero() {
         // Act:
         final FieldElement f = getZeroFieldElement();
 
         // Assert:
-        Assert.assertThat(f.isNonZero(), IsEqual.equalTo(false));
+        assertThat(f.isNonZero(), equalTo(false));
     }
 
     @Test
-    public void isNonZeroReturnsTrueIfFieldElementIsNonZero() {
+    void isNonZeroReturnsTrueIfFieldElementIsNonZero() {
         // Act:
         final FieldElement f = getNonZeroFieldElement();
 
         // Assert:
-        Assert.assertThat(f.isNonZero(), IsEqual.equalTo(true));
+        assertThat(f.isNonZero(), equalTo(true));
     }
 
     // endregion
@@ -57,7 +60,7 @@ public abstract class AbstractFieldElementTest {
     // region mod q arithmetic
 
     @Test
-    public void addReturnsCorrectResult() {
+    void addReturnsCorrectResult() {
         for (int i = 0; i < 1000; i++) {
             // Arrange:
             final FieldElement f1 = getRandomFieldElement();
@@ -70,12 +73,12 @@ public abstract class AbstractFieldElementTest {
             final BigInteger b3 = toBigInteger(f3).mod(getQ());
 
             // Assert:
-            Assert.assertThat(b3, IsEqual.equalTo(b1.add(b2).mod(getQ())));
+            assertThat(b3, equalTo(b1.add(b2).mod(getQ())));
         }
     }
 
     @Test
-    public void subtractReturnsCorrectResult() {
+    void subtractReturnsCorrectResult() {
         for (int i = 0; i < 1000; i++) {
             // Arrange:
             final FieldElement f1 = getRandomFieldElement();
@@ -88,12 +91,12 @@ public abstract class AbstractFieldElementTest {
             final BigInteger b3 = toBigInteger(f3).mod(getQ());
 
             // Assert:
-            Assert.assertThat(b3, IsEqual.equalTo(b1.subtract(b2).mod(getQ())));
+            assertThat(b3, equalTo(b1.subtract(b2).mod(getQ())));
         }
     }
 
     @Test
-    public void negateReturnsCorrectResult() {
+    void negateReturnsCorrectResult() {
         for (int i = 0; i < 1000; i++) {
             // Arrange:
             final FieldElement f1 = getRandomFieldElement();
@@ -104,12 +107,12 @@ public abstract class AbstractFieldElementTest {
             final BigInteger b2 = toBigInteger(f2).mod(getQ());
 
             // Assert:
-            Assert.assertThat(b2, IsEqual.equalTo(b1.negate().mod(getQ())));
+            assertThat(b2, equalTo(b1.negate().mod(getQ())));
         }
     }
 
     @Test
-    public void multiplyReturnsCorrectResult() {
+    void multiplyReturnsCorrectResult() {
         for (int i = 0; i < 1000; i++) {
             // Arrange:
             final FieldElement f1 = getRandomFieldElement();
@@ -122,12 +125,12 @@ public abstract class AbstractFieldElementTest {
             final BigInteger b3 = toBigInteger(f3).mod(getQ());
 
             // Assert:
-            Assert.assertThat(b3, IsEqual.equalTo(b1.multiply(b2).mod(getQ())));
+            assertThat(b3, equalTo(b1.multiply(b2).mod(getQ())));
         }
     }
 
     @Test
-    public void squareReturnsCorrectResult() {
+    void squareReturnsCorrectResult() {
         for (int i = 0; i < 1000; i++) {
             // Arrange:
             final FieldElement f1 = getRandomFieldElement();
@@ -138,12 +141,12 @@ public abstract class AbstractFieldElementTest {
             final BigInteger b2 = toBigInteger(f2).mod(getQ());
 
             // Assert:
-            Assert.assertThat(b2, IsEqual.equalTo(b1.multiply(b1).mod(getQ())));
+            assertThat(b2, equalTo(b1.multiply(b1).mod(getQ())));
         }
     }
 
     @Test
-    public void squareAndDoubleReturnsCorrectResult() {
+    void squareAndDoubleReturnsCorrectResult() {
         for (int i = 0; i < 1000; i++) {
             // Arrange:
             final FieldElement f1 = getRandomFieldElement();
@@ -154,15 +157,12 @@ public abstract class AbstractFieldElementTest {
             final BigInteger b2 = toBigInteger(f2).mod(getQ());
 
             // Assert:
-            Assert.assertThat(
-                    b2,
-                    IsEqual.equalTo(
-                            b1.multiply(b1).multiply(new BigInteger("2")).mod(getQ())));
+            assertThat(b2, equalTo(b1.multiply(b1).multiply(new BigInteger("2")).mod(getQ())));
         }
     }
 
     @Test
-    public void invertReturnsCorrectResult() {
+    void invertReturnsCorrectResult() {
         for (int i = 0; i < 1000; i++) {
             // Arrange:
             final FieldElement f1 = getRandomFieldElement();
@@ -173,12 +173,12 @@ public abstract class AbstractFieldElementTest {
             final BigInteger b2 = toBigInteger(f2).mod(getQ());
 
             // Assert:
-            Assert.assertThat(b2, IsEqual.equalTo(b1.modInverse(getQ())));
+            assertThat(b2, equalTo(b1.modInverse(getQ())));
         }
     }
 
     @Test
-    public void pow22523ReturnsCorrectResult() {
+    void pow22523ReturnsCorrectResult() {
         for (int i = 0; i < 1000; i++) {
             // Arrange:
             final FieldElement f1 = getRandomFieldElement();
@@ -189,9 +189,7 @@ public abstract class AbstractFieldElementTest {
             final BigInteger b2 = toBigInteger(f2).mod(getQ());
 
             // Assert:
-            Assert.assertThat(
-                    b2,
-                    IsEqual.equalTo(b1.modPow(BigInteger.ONE.shiftLeft(252).subtract(new BigInteger("3")), getQ())));
+            assertThat(b2, equalTo(b1.modPow(BigInteger.ONE.shiftLeft(252).subtract(new BigInteger("3")), getQ())));
         }
     }
 
@@ -200,16 +198,16 @@ public abstract class AbstractFieldElementTest {
     // region cmov
 
     @Test
-    public void cmovReturnsCorrectResult() {
+    void cmovReturnsCorrectResult() {
         final FieldElement zero = getZeroFieldElement();
         final FieldElement nz = getNonZeroFieldElement();
         final FieldElement f = getRandomFieldElement();
 
-        Assert.assertThat(zero.cmov(nz, 0), IsEqual.equalTo(zero));
-        Assert.assertThat(zero.cmov(nz, 1), IsEqual.equalTo(nz));
+        assertThat(zero.cmov(nz, 0), equalTo(zero));
+        assertThat(zero.cmov(nz, 1), equalTo(nz));
 
-        Assert.assertThat(f.cmov(nz, 0), IsEqual.equalTo(f));
-        Assert.assertThat(f.cmov(nz, 1), IsEqual.equalTo(nz));
+        assertThat(f.cmov(nz, 0), equalTo(f));
+        assertThat(f.cmov(nz, 1), equalTo(nz));
     }
 
     // endregion
@@ -217,7 +215,7 @@ public abstract class AbstractFieldElementTest {
     // region hashCode / equals
 
     @Test
-    public void equalsOnlyReturnsTrueForEquivalentObjects() {
+    void equalsOnlyReturnsTrueForEquivalentObjects() {
         // Arrange:
         final FieldElement f1 = getRandomFieldElement();
         final FieldElement f2 = getField().getEncoding().decode(f1.toByteArray());
@@ -225,14 +223,14 @@ public abstract class AbstractFieldElementTest {
         final FieldElement f4 = getRandomFieldElement();
 
         // Assert:
-        Assert.assertThat(f1, IsEqual.equalTo(f2));
-        Assert.assertThat(f1, IsNot.not(IsEqual.equalTo(f3)));
-        Assert.assertThat(f1, IsNot.not(IsEqual.equalTo(f4)));
-        Assert.assertThat(f3, IsNot.not(IsEqual.equalTo(f4)));
+        assertThat(f1, equalTo(f2));
+        assertThat(f1, IsNot.not(equalTo(f3)));
+        assertThat(f1, IsNot.not(equalTo(f4)));
+        assertThat(f3, IsNot.not(equalTo(f4)));
     }
 
     @Test
-    public void hashCodesAreEqualForEquivalentObjects() {
+    void hashCodesAreEqualForEquivalentObjects() {
         // Arrange:
         final FieldElement f1 = getRandomFieldElement();
         final FieldElement f2 = getField().getEncoding().decode(f1.toByteArray());
@@ -240,10 +238,10 @@ public abstract class AbstractFieldElementTest {
         final FieldElement f4 = getRandomFieldElement();
 
         // Assert:
-        Assert.assertThat(f1.hashCode(), IsEqual.equalTo(f2.hashCode()));
-        Assert.assertThat(f1.hashCode(), IsNot.not(IsEqual.equalTo(f3.hashCode())));
-        Assert.assertThat(f1.hashCode(), IsNot.not(IsEqual.equalTo(f4.hashCode())));
-        Assert.assertThat(f3.hashCode(), IsNot.not(IsEqual.equalTo(f4.hashCode())));
+        assertThat(f1.hashCode(), equalTo(f2.hashCode()));
+        assertThat(f1.hashCode(), IsNot.not(equalTo(f3.hashCode())));
+        assertThat(f1.hashCode(), IsNot.not(equalTo(f4.hashCode())));
+        assertThat(f3.hashCode(), IsNot.not(equalTo(f4.hashCode())));
     }
 
     // endregion

--- a/src/test/java/net/i2p/crypto/eddsa/math/ConstantsTest.java
+++ b/src/test/java/net/i2p/crypto/eddsa/math/ConstantsTest.java
@@ -11,24 +11,23 @@
  */
 package net.i2p.crypto.eddsa.math;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import net.i2p.crypto.eddsa.spec.EdDSANamedCurveSpec;
 import net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Based on the tests in checkparams.py from the Python Ed25519 implementation.
  * @author str4d
  *
  */
-public class ConstantsTest {
+class ConstantsTest {
     static final EdDSANamedCurveSpec ed25519 = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
     static final Curve curve = ed25519.getCurve();
 
@@ -39,15 +38,13 @@ public class ConstantsTest {
     static final GroupElement P3_ZERO = GroupElement.p3(curve, ZERO, ONE, ONE, ZERO);
 
     @Test
-    public void testb() {
+    void testb() {
         int b = curve.getField().getb();
         assertThat(b, is(greaterThanOrEqualTo(10)));
-        try {
+        assertDoesNotThrow(() -> {
             MessageDigest h = MessageDigest.getInstance(ed25519.getHashAlgorithm());
             assertThat(8 * h.getDigestLength(), is(equalTo(2 * b)));
-        } catch (NoSuchAlgorithmException e) {
-            fail(e.getMessage());
-        }
+        });
     }
 
     /*@Test
@@ -80,7 +77,7 @@ public class ConstantsTest {
     }*/
 
     @Test
-    public void testB() {
+    void testB() {
         GroupElement B = ed25519.getB();
         assertThat(B.isOnCurve(curve), is(true));
         // assertThat(B.scalarMultiply(new BigIntegerLittleEndianEncoding().encode(ed25519.getL(),

--- a/src/test/java/net/i2p/crypto/eddsa/math/GroupElementTest.java
+++ b/src/test/java/net/i2p/crypto/eddsa/math/GroupElementTest.java
@@ -11,23 +11,23 @@
  */
 package net.i2p.crypto.eddsa.math;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.math.BigInteger;
 import java.util.Arrays;
 import net.i2p.crypto.eddsa.*;
 import net.i2p.crypto.eddsa.spec.*;
 import org.hamcrest.core.*;
-import org.junit.*;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author str4d
  * Additional tests by NEM project team.
  *
  */
-public class GroupElementTest {
+class GroupElementTest {
     static final byte[] BYTES_ZEROZERO =
             Utils.hexToBytes("0000000000000000000000000000000000000000000000000000000000000000");
     static final byte[] BYTES_ONEONE =
@@ -57,14 +57,11 @@ public class GroupElementTest {
     static final byte[] BYTES_PKR =
             Utils.hexToBytes("3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29");
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
     /**
      * Test method for {@link GroupElement#p2(Curve, FieldElement, FieldElement, FieldElement)}.
      */
     @Test
-    public void testP2() {
+    void testP2() {
         final GroupElement t = GroupElement.p2(curve, ZERO, ONE, ONE);
         assertThat(t.curve, is(equalTo(curve)));
         assertThat(t.repr, is(GroupElement.Representation.P2));
@@ -78,7 +75,7 @@ public class GroupElementTest {
      * Test method for {@link GroupElement#p3(Curve, FieldElement, FieldElement, FieldElement, FieldElement)}.
      */
     @Test
-    public void testP3() {
+    void testP3() {
         final GroupElement t = GroupElement.p3(curve, ZERO, ONE, ONE, ZERO);
         assertThat(t.curve, is(equalTo(curve)));
         assertThat(t.repr, is(GroupElement.Representation.P3));
@@ -92,7 +89,7 @@ public class GroupElementTest {
      * Test method for {@link GroupElement#p3(Curve, FieldElement, FieldElement, FieldElement, FieldElement, boolean)}.
      */
     @Test
-    public void testP3WithExplicitFlag() {
+    void testP3WithExplicitFlag() {
         final GroupElement t = GroupElement.p3(curve, ZERO, ONE, ONE, ZERO, false);
         assertThat(t.curve, is(equalTo(curve)));
         assertThat(t.repr, is(GroupElement.Representation.P3));
@@ -106,7 +103,7 @@ public class GroupElementTest {
      * Test method for {@link GroupElement#p1p1(Curve, FieldElement, FieldElement, FieldElement, FieldElement)}.
      */
     @Test
-    public void testP1p1() {
+    void testP1p1() {
         final GroupElement t = GroupElement.p1p1(curve, ZERO, ONE, ONE, ONE);
         assertThat(t.curve, is(equalTo(curve)));
         assertThat(t.repr, is(GroupElement.Representation.P1P1));
@@ -120,7 +117,7 @@ public class GroupElementTest {
      * Test method for {@link GroupElement#precomp(Curve, FieldElement, FieldElement, FieldElement)}.
      */
     @Test
-    public void testPrecomp() {
+    void testPrecomp() {
         final GroupElement t = GroupElement.precomp(curve, ONE, ONE, ZERO);
         assertThat(t.curve, is(equalTo(curve)));
         assertThat(t.repr, is(GroupElement.Representation.PRECOMP));
@@ -134,7 +131,7 @@ public class GroupElementTest {
      * Test method for {@link GroupElement#cached(Curve, FieldElement, FieldElement, FieldElement, FieldElement)}.
      */
     @Test
-    public void testCached() {
+    void testCached() {
         final GroupElement t = GroupElement.cached(curve, ONE, ONE, ONE, ZERO);
         assertThat(t.curve, is(equalTo(curve)));
         assertThat(t.repr, is(GroupElement.Representation.CACHED));
@@ -148,7 +145,7 @@ public class GroupElementTest {
      * Test method for {@link GroupElement#GroupElement(Curve, GroupElement.Representation, FieldElement, FieldElement, FieldElement, FieldElement)}.
      */
     @Test
-    public void testGroupElementCurveRepresentationFieldElementFieldElementFieldElementFieldElement() {
+    void testGroupElementCurveRepresentationFieldElementFieldElementFieldElementFieldElement() {
         final GroupElement t = new GroupElement(curve, GroupElement.Representation.P3, ZERO, ONE, ONE, ZERO);
         assertThat(t.curve, is(equalTo(curve)));
         assertThat(t.repr, is(GroupElement.Representation.P3));
@@ -162,7 +159,7 @@ public class GroupElementTest {
      * Test method for {@link GroupElement#GroupElement(Curve, GroupElement.Representation, FieldElement, FieldElement, FieldElement, FieldElement, boolean)}.
      */
     @Test
-    public void testGroupElementCurveRepresentationFieldElementFieldElementFieldElementFieldElementWithExplicitFlag() {
+    void testGroupElementCurveRepresentationFieldElementFieldElementFieldElementFieldElementWithExplicitFlag() {
         final GroupElement t = new GroupElement(curve, GroupElement.Representation.P3, ZERO, ONE, ONE, ZERO, false);
         assertThat(t.curve, is(equalTo(curve)));
         assertThat(t.repr, is(GroupElement.Representation.P3));
@@ -177,7 +174,7 @@ public class GroupElementTest {
      * {@link GroupElement#toByteArray()} against valid public keys.
      */
     @Test
-    public void testToAndFromByteArray() {
+    void testToAndFromByteArray() {
         GroupElement t;
         for (Ed25519TestVectors.TestTuple testCase : Ed25519TestVectors.testCases) {
             t = new GroupElement(curve, testCase.pk);
@@ -189,14 +186,14 @@ public class GroupElementTest {
      * Test method for {@link GroupElement#GroupElement(Curve, byte[])}.
      */
     @Test
-    public void testGroupElementByteArray() {
+    void testGroupElementByteArray() {
         final GroupElement t = new GroupElement(curve, BYTES_PKR);
         final GroupElement s = GroupElement.p3(curve, PKR[0], PKR[1], ONE, PKR[0].multiply(PKR[1]));
         assertThat(t, is(equalTo(s)));
     }
 
     @Test
-    public void constructorUsingByteArrayReturnsExpectedResult() {
+    void constructorUsingByteArrayReturnsExpectedResult() {
         for (int i = 0; i < 100; i++) {
             // Arrange:
             final GroupElement g = MathUtils.getRandomGroupElement();
@@ -207,7 +204,7 @@ public class GroupElementTest {
             final GroupElement h2 = MathUtils.toGroupElement(bytes);
 
             // Assert:
-            Assert.assertThat(h1, IsEqual.equalTo(h2));
+            assertThat(h1, equalTo(h2));
         }
     }
 
@@ -217,7 +214,7 @@ public class GroupElementTest {
      * TODO 20141001 BR: why test with points which are not on the curve?
      */
     @Test
-    public void testToByteArray() {
+    void testToByteArray() {
         byte[] zerozero = GroupElement.p2(curve, ZERO, ZERO, ONE).toByteArray();
         assertThat(zerozero.length, is(equalTo(BYTES_ZEROZERO.length)));
         assertThat(zerozero, is(equalTo(BYTES_ZEROZERO)));
@@ -240,7 +237,7 @@ public class GroupElementTest {
     }
 
     @Test
-    public void toByteArrayReturnsExpectedResult() {
+    void toByteArrayReturnsExpectedResult() {
         for (int i = 0; i < 100; i++) {
             // Arrange:
             final GroupElement g = MathUtils.getRandomGroupElement();
@@ -253,7 +250,7 @@ public class GroupElementTest {
             }
 
             // Assert:
-            Assert.assertThat(Arrays.equals(gBytes, bytes), IsEqual.equalTo(true));
+            assertThat(Arrays.equals(gBytes, bytes), equalTo(true));
         }
     }
 
@@ -263,7 +260,7 @@ public class GroupElementTest {
      * Test method for {@link GroupElement#toP2()}.
      */
     @Test
-    public void testToP2() {
+    void testToP2() {
         GroupElement p3zero = curve.getZero(GroupElement.Representation.P3);
         GroupElement t = p3zero.toP2();
         assertThat(t.repr, is(GroupElement.Representation.P2));
@@ -281,28 +278,24 @@ public class GroupElementTest {
         assertThat(t.T, is((FieldElement) null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void toP2ThrowsIfGroupElementHasPrecompRepresentation() {
-        // Arrange:
+    @Test
+    void toP2ThrowsIfGroupElementHasPrecompRepresentation() {
         final GroupElement g =
                 MathUtils.toRepresentation(MathUtils.getRandomGroupElement(), GroupElement.Representation.PRECOMP);
-
         // Assert:
-        g.toP2();
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void toP2ThrowsIfGroupElementHasCachedRepresentation() {
-        // Arrange:
-        final GroupElement g =
-                MathUtils.toRepresentation(MathUtils.getRandomGroupElement(), GroupElement.Representation.CACHED);
-
-        // Assert:
-        g.toP2();
+        assertThrows(IllegalArgumentException.class, g::toP2);
     }
 
     @Test
-    public void toP2ReturnsExpectedResultIfGroupElementHasP2Representation() {
+    void toP2ThrowsIfGroupElementHasCachedRepresentation() {
+        final GroupElement g =
+                MathUtils.toRepresentation(MathUtils.getRandomGroupElement(), GroupElement.Representation.CACHED);
+        // Assert:
+        assertThrows(IllegalArgumentException.class, g::toP2);
+    }
+
+    @Test
+    void toP2ReturnsExpectedResultIfGroupElementHasP2Representation() {
         for (int i = 0; i < 10; i++) {
             // Arrange:
             final GroupElement g =
@@ -312,17 +305,17 @@ public class GroupElementTest {
             final GroupElement h = g.toP2();
 
             // Assert:
-            Assert.assertThat(h, IsEqual.equalTo(g));
-            Assert.assertThat(h.getRepresentation(), IsEqual.equalTo(GroupElement.Representation.P2));
-            Assert.assertThat(h.getX(), IsEqual.equalTo(g.getX()));
-            Assert.assertThat(h.getY(), IsEqual.equalTo(g.getY()));
-            Assert.assertThat(h.getZ(), IsEqual.equalTo(g.getZ()));
-            Assert.assertThat(h.getT(), IsEqual.equalTo(null));
+            assertThat(h, equalTo(g));
+            assertThat(h.getRepresentation(), equalTo(GroupElement.Representation.P2));
+            assertThat(h.getX(), equalTo(g.getX()));
+            assertThat(h.getY(), equalTo(g.getY()));
+            assertThat(h.getZ(), equalTo(g.getZ()));
+            assertThat(h.getT(), equalTo(null));
         }
     }
 
     @Test
-    public void toP2ReturnsExpectedResultIfGroupElementHasP3Representation() {
+    void toP2ReturnsExpectedResultIfGroupElementHasP3Representation() {
         for (int i = 0; i < 10; i++) {
             // Arrange:
             final GroupElement g = MathUtils.getRandomGroupElement();
@@ -332,17 +325,17 @@ public class GroupElementTest {
             final GroupElement h2 = MathUtils.toRepresentation(g, GroupElement.Representation.P2);
 
             // Assert:
-            Assert.assertThat(h1, IsEqual.equalTo(h2));
-            Assert.assertThat(h1.getRepresentation(), IsEqual.equalTo(GroupElement.Representation.P2));
-            Assert.assertThat(h1.getX(), IsEqual.equalTo(g.getX()));
-            Assert.assertThat(h1.getY(), IsEqual.equalTo(g.getY()));
-            Assert.assertThat(h1.getZ(), IsEqual.equalTo(g.getZ()));
-            Assert.assertThat(h1.getT(), IsEqual.equalTo(null));
+            assertThat(h1, equalTo(h2));
+            assertThat(h1.getRepresentation(), equalTo(GroupElement.Representation.P2));
+            assertThat(h1.getX(), equalTo(g.getX()));
+            assertThat(h1.getY(), equalTo(g.getY()));
+            assertThat(h1.getZ(), equalTo(g.getZ()));
+            assertThat(h1.getT(), equalTo(null));
         }
     }
 
     @Test
-    public void toP2ReturnsExpectedResultIfGroupElementHasP1P1Representation() {
+    void toP2ReturnsExpectedResultIfGroupElementHasP1P1Representation() {
         for (int i = 0; i < 10; i++) {
             // Arrange:
             final GroupElement g =
@@ -353,47 +346,41 @@ public class GroupElementTest {
             final GroupElement h2 = MathUtils.toRepresentation(g, GroupElement.Representation.P2);
 
             // Assert:
-            Assert.assertThat(h1, IsEqual.equalTo(h2));
-            Assert.assertThat(h1.getRepresentation(), IsEqual.equalTo(GroupElement.Representation.P2));
-            Assert.assertThat(h1.getX(), IsEqual.equalTo(g.getX().multiply(g.getT())));
-            Assert.assertThat(h1.getY(), IsEqual.equalTo(g.getY().multiply(g.getZ())));
-            Assert.assertThat(h1.getZ(), IsEqual.equalTo(g.getZ().multiply(g.getT())));
-            Assert.assertThat(h1.getT(), IsEqual.equalTo(null));
+            assertThat(h1, equalTo(h2));
+            assertThat(h1.getRepresentation(), equalTo(GroupElement.Representation.P2));
+            assertThat(h1.getX(), equalTo(g.getX().multiply(g.getT())));
+            assertThat(h1.getY(), equalTo(g.getY().multiply(g.getZ())));
+            assertThat(h1.getZ(), equalTo(g.getZ().multiply(g.getT())));
+            assertThat(h1.getT(), equalTo(null));
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void toP3ThrowsIfGroupElementHasP2Representation() {
-        // Arrange:
+    @Test
+    void toP3ThrowsIfGroupElementHasP2Representation() {
         final GroupElement g =
                 MathUtils.toRepresentation(MathUtils.getRandomGroupElement(), GroupElement.Representation.P2);
-
         // Assert:
-        g.toP3();
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void toP3ThrowsIfGroupElementHasPrecompRepresentation() {
-        // Arrange:
-        final GroupElement g =
-                MathUtils.toRepresentation(MathUtils.getRandomGroupElement(), GroupElement.Representation.PRECOMP);
-
-        // Assert:
-        g.toP3();
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void toP3ThrowsIfGroupElementHasCachedRepresentation() {
-        // Arrange:
-        final GroupElement g =
-                MathUtils.toRepresentation(MathUtils.getRandomGroupElement(), GroupElement.Representation.CACHED);
-
-        // Assert:
-        g.toP3();
+        assertThrows(IllegalArgumentException.class, g::toP3);
     }
 
     @Test
-    public void toP3ReturnsExpectedResultIfGroupElementHasP1P1Representation() {
+    void toP3ThrowsIfGroupElementHasPrecompRepresentation() {
+        final GroupElement g =
+                MathUtils.toRepresentation(MathUtils.getRandomGroupElement(), GroupElement.Representation.PRECOMP);
+        // Assert:
+        assertThrows(IllegalArgumentException.class, g::toP3);
+    }
+
+    @Test
+    void toP3ThrowsIfGroupElementHasCachedRepresentation() {
+        final GroupElement g =
+                MathUtils.toRepresentation(MathUtils.getRandomGroupElement(), GroupElement.Representation.CACHED);
+        // Assert:
+        assertThrows(IllegalArgumentException.class, g::toP3);
+    }
+
+    @Test
+    void toP3ReturnsExpectedResultIfGroupElementHasP1P1Representation() {
         for (int i = 0; i < 10; i++) {
             // Arrange:
             final GroupElement g =
@@ -404,17 +391,17 @@ public class GroupElementTest {
             final GroupElement h2 = MathUtils.toRepresentation(g, GroupElement.Representation.P3);
 
             // Assert:
-            Assert.assertThat(h1, IsEqual.equalTo(h2));
-            Assert.assertThat(h1.getRepresentation(), IsEqual.equalTo(GroupElement.Representation.P3));
-            Assert.assertThat(h1.getX(), IsEqual.equalTo(g.getX().multiply(g.getT())));
-            Assert.assertThat(h1.getY(), IsEqual.equalTo(g.getY().multiply(g.getZ())));
-            Assert.assertThat(h1.getZ(), IsEqual.equalTo(g.getZ().multiply(g.getT())));
-            Assert.assertThat(h1.getT(), IsEqual.equalTo(g.getX().multiply(g.getY())));
+            assertThat(h1, equalTo(h2));
+            assertThat(h1.getRepresentation(), equalTo(GroupElement.Representation.P3));
+            assertThat(h1.getX(), equalTo(g.getX().multiply(g.getT())));
+            assertThat(h1.getY(), equalTo(g.getY().multiply(g.getZ())));
+            assertThat(h1.getZ(), equalTo(g.getZ().multiply(g.getT())));
+            assertThat(h1.getT(), equalTo(g.getX().multiply(g.getY())));
         }
     }
 
     @Test
-    public void toP3ReturnsExpectedResultIfGroupElementHasP3Representation() {
+    void toP3ReturnsExpectedResultIfGroupElementHasP3Representation() {
         for (int i = 0; i < 10; i++) {
             // Arrange:
             final GroupElement g = MathUtils.getRandomGroupElement();
@@ -423,18 +410,18 @@ public class GroupElementTest {
             final GroupElement h = g.toP3();
 
             // Assert:
-            Assert.assertThat(h, IsEqual.equalTo(g));
-            Assert.assertThat(h.getRepresentation(), IsEqual.equalTo(GroupElement.Representation.P3));
-            Assert.assertThat(h, IsEqual.equalTo(g));
-            Assert.assertThat(h.getX(), IsEqual.equalTo(g.getX()));
-            Assert.assertThat(h.getY(), IsEqual.equalTo(g.getY()));
-            Assert.assertThat(h.getZ(), IsEqual.equalTo(g.getZ()));
-            Assert.assertThat(h.getT(), IsEqual.equalTo(g.getT()));
+            assertThat(h, equalTo(g));
+            assertThat(h.getRepresentation(), equalTo(GroupElement.Representation.P3));
+            assertThat(h, equalTo(g));
+            assertThat(h.getX(), equalTo(g.getX()));
+            assertThat(h.getY(), equalTo(g.getY()));
+            assertThat(h.getZ(), equalTo(g.getZ()));
+            assertThat(h.getT(), equalTo(g.getT()));
         }
     }
 
     @Test
-    public void toP3PrecomputeDoubleReturnsExpectedResultIfGroupElementHasP1P1Representation() {
+    void toP3PrecomputeDoubleReturnsExpectedResultIfGroupElementHasP1P1Representation() {
         for (int i = 0; i < 10; i++) {
             // Arrange:
             final GroupElement g =
@@ -445,50 +432,44 @@ public class GroupElementTest {
             final GroupElement h2 = MathUtils.toRepresentation(g, GroupElement.Representation.P3PrecomputedDouble);
 
             // Assert:
-            Assert.assertThat(h1, IsEqual.equalTo(h2));
-            Assert.assertThat(h1.getRepresentation(), IsEqual.equalTo(GroupElement.Representation.P3));
-            Assert.assertThat(h1.getX(), IsEqual.equalTo(g.getX().multiply(g.getT())));
-            Assert.assertThat(h1.getY(), IsEqual.equalTo(g.getY().multiply(g.getZ())));
-            Assert.assertThat(h1.getZ(), IsEqual.equalTo(g.getZ().multiply(g.getT())));
-            Assert.assertThat(h1.getT(), IsEqual.equalTo(g.getX().multiply(g.getY())));
-            Assert.assertThat(h1.precmp, IsNull.nullValue());
-            Assert.assertThat(h1.dblPrecmp, IsNull.notNullValue());
-            Assert.assertThat(h1.dblPrecmp, IsEqual.equalTo(h2.dblPrecmp));
+            assertThat(h1, equalTo(h2));
+            assertThat(h1.getRepresentation(), equalTo(GroupElement.Representation.P3));
+            assertThat(h1.getX(), equalTo(g.getX().multiply(g.getT())));
+            assertThat(h1.getY(), equalTo(g.getY().multiply(g.getZ())));
+            assertThat(h1.getZ(), equalTo(g.getZ().multiply(g.getT())));
+            assertThat(h1.getT(), equalTo(g.getX().multiply(g.getY())));
+            assertThat(h1.precmp, IsNull.nullValue());
+            assertThat(h1.dblPrecmp, IsNull.notNullValue());
+            assertThat(h1.dblPrecmp, equalTo(h2.dblPrecmp));
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void toCachedThrowsIfGroupElementHasP2Representation() {
-        // Arrange:
+    @Test
+    void toCachedThrowsIfGroupElementHasP2Representation() {
         final GroupElement g =
                 MathUtils.toRepresentation(MathUtils.getRandomGroupElement(), GroupElement.Representation.P2);
-
         // Assert:
-        g.toCached();
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void toCachedThrowsIfGroupElementHasPrecompRepresentation() {
-        // Arrange:
-        final GroupElement g =
-                MathUtils.toRepresentation(MathUtils.getRandomGroupElement(), GroupElement.Representation.PRECOMP);
-
-        // Assert:
-        g.toCached();
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void toCachedThrowsIfGroupElementHasP1P1Representation() {
-        // Arrange:
-        final GroupElement g =
-                MathUtils.toRepresentation(MathUtils.getRandomGroupElement(), GroupElement.Representation.P1P1);
-
-        // Assert:
-        g.toCached();
+        assertThrows(IllegalArgumentException.class, g::toCached);
     }
 
     @Test
-    public void toCachedReturnsExpectedResultIfGroupElementHasCachedRepresentation() {
+    void toCachedThrowsIfGroupElementHasPrecompRepresentation() {
+        final GroupElement g =
+                MathUtils.toRepresentation(MathUtils.getRandomGroupElement(), GroupElement.Representation.PRECOMP);
+        // Assert:
+        assertThrows(IllegalArgumentException.class, g::toCached);
+    }
+
+    @Test
+    void toCachedThrowsIfGroupElementHasP1P1Representation() {
+        final GroupElement g =
+                MathUtils.toRepresentation(MathUtils.getRandomGroupElement(), GroupElement.Representation.P1P1);
+        // Assert:
+        assertThrows(IllegalArgumentException.class, g::toCached);
+    }
+
+    @Test
+    void toCachedReturnsExpectedResultIfGroupElementHasCachedRepresentation() {
         for (int i = 0; i < 10; i++) {
             // Arrange:
             final GroupElement g =
@@ -498,18 +479,18 @@ public class GroupElementTest {
             final GroupElement h = g.toCached();
 
             // Assert:
-            Assert.assertThat(h, IsEqual.equalTo(g));
-            Assert.assertThat(h.getRepresentation(), IsEqual.equalTo(GroupElement.Representation.CACHED));
-            Assert.assertThat(h, IsEqual.equalTo(g));
-            Assert.assertThat(h.getX(), IsEqual.equalTo(g.getX()));
-            Assert.assertThat(h.getY(), IsEqual.equalTo(g.getY()));
-            Assert.assertThat(h.getZ(), IsEqual.equalTo(g.getZ()));
-            Assert.assertThat(h.getT(), IsEqual.equalTo(g.getT()));
+            assertThat(h, equalTo(g));
+            assertThat(h.getRepresentation(), equalTo(GroupElement.Representation.CACHED));
+            assertThat(h, equalTo(g));
+            assertThat(h.getX(), equalTo(g.getX()));
+            assertThat(h.getY(), equalTo(g.getY()));
+            assertThat(h.getZ(), equalTo(g.getZ()));
+            assertThat(h.getT(), equalTo(g.getT()));
         }
     }
 
     @Test
-    public void toCachedReturnsExpectedResultIfGroupElementHasP3Representation() {
+    void toCachedReturnsExpectedResultIfGroupElementHasP3Representation() {
         for (int i = 0; i < 10; i++) {
             // Arrange:
             final GroupElement g = MathUtils.getRandomGroupElement();
@@ -519,13 +500,13 @@ public class GroupElementTest {
             final GroupElement h2 = MathUtils.toRepresentation(g, GroupElement.Representation.CACHED);
 
             // Assert:
-            Assert.assertThat(h1, IsEqual.equalTo(h2));
-            Assert.assertThat(h1.getRepresentation(), IsEqual.equalTo(GroupElement.Representation.CACHED));
-            Assert.assertThat(h1, IsEqual.equalTo(g));
-            Assert.assertThat(h1.getX(), IsEqual.equalTo(g.getY().add(g.getX())));
-            Assert.assertThat(h1.getY(), IsEqual.equalTo(g.getY().subtract(g.getX())));
-            Assert.assertThat(h1.getZ(), IsEqual.equalTo(g.getZ()));
-            Assert.assertThat(h1.getT(), IsEqual.equalTo(g.getT().multiply(curve.get2D())));
+            assertThat(h1, equalTo(h2));
+            assertThat(h1.getRepresentation(), equalTo(GroupElement.Representation.CACHED));
+            assertThat(h1, equalTo(g));
+            assertThat(h1.getX(), equalTo(g.getY().add(g.getX())));
+            assertThat(h1.getY(), equalTo(g.getY().subtract(g.getX())));
+            assertThat(h1.getZ(), equalTo(g.getZ()));
+            assertThat(h1.getT(), equalTo(g.getT().multiply(curve.get2D())));
         }
     }
 
@@ -535,14 +516,14 @@ public class GroupElementTest {
      * Test method for precomputation.
      */
     @Test
-    public void testPrecompute() {
+    void testPrecompute() {
         GroupElement B = ed25519.getB();
         assertThat(B.precmp, is(equalTo(PrecomputationTestVectors.testPrecmp)));
         assertThat(B.dblPrecmp, is(equalTo(PrecomputationTestVectors.testDblPrecmp)));
     }
 
     @Test
-    public void precomputedTableContainsExpectedGroupElements() {
+    void precomputedTableContainsExpectedGroupElements() {
         // Arrange:
         GroupElement g = ed25519.getB();
 
@@ -550,9 +531,9 @@ public class GroupElementTest {
         for (int i = 0; i < 32; i++) {
             GroupElement h = g;
             for (int j = 0; j < 8; j++) {
-                Assert.assertThat(
+                assertThat(
                         MathUtils.toRepresentation(h, GroupElement.Representation.PRECOMP),
-                        IsEqual.equalTo(ed25519.getB().precmp[i][j]));
+                        equalTo(ed25519.getB().precmp[i][j]));
                 h = MathUtils.addGroupElements(h, g);
             }
             for (int k = 0; k < 8; k++) {
@@ -562,16 +543,16 @@ public class GroupElementTest {
     }
 
     @Test
-    public void dblPrecomputedTableContainsExpectedGroupElements() {
+    void dblPrecomputedTableContainsExpectedGroupElements() {
         // Arrange:
         GroupElement g = ed25519.getB();
         GroupElement h = MathUtils.addGroupElements(g, g);
 
         // Act + Assert:
         for (int i = 0; i < 8; i++) {
-            Assert.assertThat(
+            assertThat(
                     MathUtils.toRepresentation(g, GroupElement.Representation.PRECOMP),
-                    IsEqual.equalTo(ed25519.getB().dblPrecmp[i]));
+                    equalTo(ed25519.getB().dblPrecmp[i]));
             g = MathUtils.addGroupElements(g, h);
         }
     }
@@ -580,14 +561,14 @@ public class GroupElementTest {
      * Test method for {@link GroupElement#dbl()}.
      */
     @Test
-    public void testDbl() {
+    void testDbl() {
         GroupElement B = ed25519.getB();
         // 2 * B = B + B
         assertThat(B.dbl(), is(equalTo(B.add(B.toCached()))));
     }
 
     @Test
-    public void dblReturnsExpectedResult() {
+    void dblReturnsExpectedResult() {
         for (int i = 0; i < 1000; i++) {
             // Arrange:
             final GroupElement g = MathUtils.getRandomGroupElement();
@@ -597,12 +578,12 @@ public class GroupElementTest {
             final GroupElement h2 = MathUtils.doubleGroupElement(g);
 
             // Assert:
-            Assert.assertThat(h2, IsEqual.equalTo(h1));
+            assertThat(h2, equalTo(h1));
         }
     }
 
     @Test
-    public void addingNeutralGroupElementDoesNotChangeGroupElement() {
+    void addingNeutralGroupElementDoesNotChangeGroupElement() {
         final GroupElement neutral = GroupElement.p3(
                 curve, curve.getField().ZERO, curve.getField().ONE, curve.getField().ONE, curve.getField().ZERO);
         for (int i = 0; i < 1000; i++) {
@@ -614,13 +595,13 @@ public class GroupElementTest {
             final GroupElement h2 = neutral.add(g.toCached());
 
             // Assert:
-            Assert.assertThat(g, IsEqual.equalTo(h1));
-            Assert.assertThat(g, IsEqual.equalTo(h2));
+            assertThat(g, equalTo(h1));
+            assertThat(g, equalTo(h2));
         }
     }
 
     @Test
-    public void addReturnsExpectedResult() {
+    void addReturnsExpectedResult() {
         for (int i = 0; i < 1000; i++) {
             // Arrange:
             final GroupElement g1 = MathUtils.getRandomGroupElement();
@@ -631,12 +612,12 @@ public class GroupElementTest {
             final GroupElement h2 = MathUtils.addGroupElements(g1, g2);
 
             // Assert:
-            Assert.assertThat(h2, IsEqual.equalTo(h1));
+            assertThat(h2, equalTo(h1));
         }
     }
 
     @Test
-    public void subReturnsExpectedResult() {
+    void subReturnsExpectedResult() {
         for (int i = 0; i < 1000; i++) {
             // Arrange:
             final GroupElement g1 = MathUtils.getRandomGroupElement();
@@ -647,7 +628,7 @@ public class GroupElementTest {
             final GroupElement h2 = MathUtils.addGroupElements(g1, MathUtils.negateGroupElement(g2));
 
             // Assert:
-            Assert.assertThat(h2, IsEqual.equalTo(h1));
+            assertThat(h2, equalTo(h1));
         }
     }
 
@@ -656,12 +637,12 @@ public class GroupElementTest {
      * Test method for {@link GroupElement#equals(Object)}.
      */
     @Test
-    public void testEqualsObject() {
+    void testEqualsObject() {
         assertThat(GroupElement.p2(curve, ZERO, ONE, ONE), is(equalTo(P2_ZERO)));
     }
 
     @Test
-    public void equalsOnlyReturnsTrueForEquivalentObjects() {
+    void equalsOnlyReturnsTrueForEquivalentObjects() {
         // Arrange:
         final GroupElement g1 = MathUtils.getRandomGroupElement();
         final GroupElement g2 = MathUtils.toRepresentation(g1, GroupElement.Representation.P2);
@@ -670,17 +651,17 @@ public class GroupElementTest {
         final GroupElement g5 = MathUtils.getRandomGroupElement();
 
         // Assert
-        Assert.assertThat(g2, IsEqual.equalTo(g1));
-        Assert.assertThat(g3, IsEqual.equalTo(g1));
-        Assert.assertThat(g1, IsEqual.equalTo(g4));
-        Assert.assertThat(g1, IsNot.not(IsEqual.equalTo(g5)));
-        Assert.assertThat(g2, IsNot.not(IsEqual.equalTo(g5)));
-        Assert.assertThat(g3, IsNot.not(IsEqual.equalTo(g5)));
-        Assert.assertThat(g5, IsNot.not(IsEqual.equalTo(g4)));
+        assertThat(g2, equalTo(g1));
+        assertThat(g3, equalTo(g1));
+        assertThat(g1, equalTo(g4));
+        assertThat(g1, IsNot.not(equalTo(g5)));
+        assertThat(g2, IsNot.not(equalTo(g5)));
+        assertThat(g3, IsNot.not(equalTo(g5)));
+        assertThat(g5, IsNot.not(equalTo(g4)));
     }
 
     @Test
-    public void hashCodesAreEqualForEquivalentObjects() {
+    void hashCodesAreEqualForEquivalentObjects() {
         // Arrange:
         final GroupElement g1 = MathUtils.getRandomGroupElement();
         final GroupElement g2 = MathUtils.toRepresentation(g1, GroupElement.Representation.P2);
@@ -688,11 +669,11 @@ public class GroupElementTest {
         final GroupElement g4 = MathUtils.getRandomGroupElement();
 
         // Assert
-        Assert.assertThat(g2.hashCode(), IsEqual.equalTo(g1.hashCode()));
-        Assert.assertThat(g3.hashCode(), IsEqual.equalTo(g1.hashCode()));
-        Assert.assertThat(g1.hashCode(), IsNot.not(IsEqual.equalTo(g4.hashCode())));
-        Assert.assertThat(g2.hashCode(), IsNot.not(IsEqual.equalTo(g4.hashCode())));
-        Assert.assertThat(g3.hashCode(), IsNot.not(IsEqual.equalTo(g4.hashCode())));
+        assertThat(g2.hashCode(), equalTo(g1.hashCode()));
+        assertThat(g3.hashCode(), equalTo(g1.hashCode()));
+        assertThat(g1.hashCode(), IsNot.not(equalTo(g4.hashCode())));
+        assertThat(g2.hashCode(), IsNot.not(equalTo(g4.hashCode())));
+        assertThat(g3.hashCode(), IsNot.not(equalTo(g4.hashCode())));
     }
 
     // endregion
@@ -716,7 +697,7 @@ public class GroupElementTest {
      * Test method for {@link GroupElement#toRadix16(byte[])}.
      */
     @Test
-    public void testToRadix16() {
+    void testToRadix16() {
         assertThat(GroupElement.toRadix16(BYTES_ZERO), is(RADIX16_ZERO));
         assertThat(GroupElement.toRadix16(BYTES_ONE), is(RADIX16_ONE));
         assertThat(GroupElement.toRadix16(BYTES_42), is(RADIX16_42));
@@ -731,9 +712,9 @@ public class GroupElementTest {
         assertThat(total, is(1234567890));
 
         byte[] pkrR16 = GroupElement.toRadix16(BYTES_PKR);
-        for (int i = 0; i < pkrR16.length; i++) {
-            assertThat(pkrR16[i], is(greaterThanOrEqualTo((byte) -8)));
-            assertThat(pkrR16[i], is(lessThanOrEqualTo((byte) 8)));
+        for (byte b : pkrR16) {
+            assertThat(b, is(greaterThanOrEqualTo((byte) -8)));
+            assertThat(b, is(lessThanOrEqualTo((byte) 8)));
         }
     }
 
@@ -741,7 +722,7 @@ public class GroupElementTest {
      * Test method for {@link GroupElement#cmov(GroupElement, int)}.
      */
     @Test
-    public void testCmov() {
+    void testCmov() {
         GroupElement a = curve.getZero(GroupElement.Representation.PRECOMP);
         GroupElement b = GroupElement.precomp(curve, TWO, ZERO, TEN);
         assertThat(a.cmov(b, 0), is(equalTo(a)));
@@ -752,7 +733,7 @@ public class GroupElementTest {
      * Test method for {@link GroupElement#select(int, int)}.
      */
     @Test
-    public void testSelect() {
+    void testSelect() {
         GroupElement B = ed25519.getB();
         for (int i = 0; i < 32; i++) {
             // 16^i 0 B
@@ -776,7 +757,7 @@ public class GroupElementTest {
      * Test values generated with Python Ed25519 implementation.
      */
     @Test
-    public void testScalarMultiplyByteArray() {
+    void testScalarMultiplyByteArray() {
         // Little-endian
         byte[] zero = Utils.hexToBytes("0000000000000000000000000000000000000000000000000000000000000000");
         byte[] one = Utils.hexToBytes("0100000000000000000000000000000000000000000000000000000000000000");
@@ -799,7 +780,7 @@ public class GroupElementTest {
     }
 
     @Test
-    public void scalarMultiplyBasePointWithZeroReturnsNeutralElement() {
+    void scalarMultiplyBasePointWithZeroReturnsNeutralElement() {
         // Arrange:
         final GroupElement basePoint = ed25519.getB();
 
@@ -807,11 +788,11 @@ public class GroupElementTest {
         final GroupElement g = basePoint.scalarMultiply(curve.getField().ZERO.toByteArray());
 
         // Assert:
-        Assert.assertThat(curve.getZero(GroupElement.Representation.P3), IsEqual.equalTo(g));
+        assertThat(curve.getZero(GroupElement.Representation.P3), equalTo(g));
     }
 
     @Test
-    public void scalarMultiplyBasePointWithOneReturnsBasePoint() {
+    void scalarMultiplyBasePointWithOneReturnsBasePoint() {
         // Arrange:
         final GroupElement basePoint = ed25519.getB();
 
@@ -819,12 +800,12 @@ public class GroupElementTest {
         final GroupElement g = basePoint.scalarMultiply(curve.getField().ONE.toByteArray());
 
         // Assert:
-        Assert.assertThat(basePoint, IsEqual.equalTo(g));
+        assertThat(basePoint, equalTo(g));
     }
 
     // This test is slow (~6s) due to math utils using an inferior algorithm to calculate the result.
     @Test
-    public void scalarMultiplyBasePointReturnsExpectedResult() {
+    void scalarMultiplyBasePointReturnsExpectedResult() {
         for (int i = 0; i < 10; i++) {
             // Arrange:
             final GroupElement basePoint = ed25519.getB();
@@ -835,12 +816,12 @@ public class GroupElementTest {
             final GroupElement h = MathUtils.scalarMultiplyGroupElement(basePoint, f);
 
             // Assert:
-            Assert.assertThat(g, IsEqual.equalTo(h));
+            assertThat(g, equalTo(h));
         }
     }
 
     @Test
-    public void testDoubleScalarMultiplyVariableTime() {
+    void testDoubleScalarMultiplyVariableTime() {
         // Little-endian
         byte[] zero = Utils.hexToBytes("0000000000000000000000000000000000000000000000000000000000000000");
         byte[] one = Utils.hexToBytes("0100000000000000000000000000000000000000000000000000000000000000");
@@ -880,7 +861,7 @@ public class GroupElementTest {
 
     // This test is slow (~6s) due to math utils using an inferior algorithm to calculate the result.
     @Test
-    public void doubleScalarMultiplyVariableTimeReturnsExpectedResult() {
+    void doubleScalarMultiplyVariableTimeReturnsExpectedResult() {
         for (int i = 0; i < 10; i++) {
             // Arrange:
             final GroupElement basePoint = ed25519.getB();
@@ -893,7 +874,7 @@ public class GroupElementTest {
             final GroupElement h2 = MathUtils.doubleScalarMultiplyGroupElements(basePoint, f1, g, f2);
 
             // Assert:
-            Assert.assertThat(h1, IsEqual.equalTo(h2));
+            assertThat(h1, equalTo(h2));
         }
     }
 
@@ -903,7 +884,7 @@ public class GroupElementTest {
      * Test method for {@link GroupElement#isOnCurve(Curve)}.
      */
     @Test
-    public void testIsOnCurve() {
+    void testIsOnCurve() {
         assertThat(P2_ZERO.isOnCurve(curve), is(true));
         assertThat(GroupElement.p2(curve, ZERO, ZERO, ONE).isOnCurve(curve), is(false));
         assertThat(GroupElement.p2(curve, ONE, ONE, ONE).isOnCurve(curve), is(false));
@@ -913,18 +894,18 @@ public class GroupElementTest {
     }
 
     @Test
-    public void isOnCurveReturnsTrueForPointsOnTheCurve() {
+    void isOnCurveReturnsTrueForPointsOnTheCurve() {
         for (int i = 0; i < 100; i++) {
             // Arrange:
             final GroupElement g = MathUtils.getRandomGroupElement();
 
             // Assert:
-            Assert.assertThat(g.isOnCurve(), IsEqual.equalTo(true));
+            assertThat(g.isOnCurve(), equalTo(true));
         }
     }
 
     @Test
-    public void isOnCurveReturnsFalseForPointsNotOnTheCurve() {
+    void isOnCurveReturnsFalseForPointsNotOnTheCurve() {
         for (int i = 0; i < 100; i++) {
             // Arrange:
             final GroupElement g = MathUtils.getRandomGroupElement();
@@ -932,7 +913,7 @@ public class GroupElementTest {
                     GroupElement.p2(curve, g.getX(), g.getY(), g.getZ().multiply(curve.getField().TWO));
 
             // Assert (can only fail for 5*Z^2=1):
-            Assert.assertThat(h.isOnCurve(), IsEqual.equalTo(false));
+            assertThat(h.isOnCurve(), equalTo(false));
         }
     }
 }

--- a/src/test/java/net/i2p/crypto/eddsa/math/bigint/BigIntegerFieldElementTest.java
+++ b/src/test/java/net/i2p/crypto/eddsa/math/bigint/BigIntegerFieldElementTest.java
@@ -11,8 +11,8 @@
  */
 package net.i2p.crypto.eddsa.math.bigint;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.math.BigInteger;
 import java.util.Random;
@@ -21,13 +21,13 @@ import net.i2p.crypto.eddsa.math.AbstractFieldElementTest;
 import net.i2p.crypto.eddsa.math.Field;
 import net.i2p.crypto.eddsa.math.FieldElement;
 import net.i2p.crypto.eddsa.math.MathUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author str4d
  *
  */
-public class BigIntegerFieldElementTest extends AbstractFieldElementTest {
+class BigIntegerFieldElementTest extends AbstractFieldElementTest {
     static final byte[] BYTES_ZERO =
             Utils.hexToBytes("0000000000000000000000000000000000000000000000000000000000000000");
     static final byte[] BYTES_ONE =
@@ -69,7 +69,7 @@ public class BigIntegerFieldElementTest extends AbstractFieldElementTest {
      * Test method for {@link BigIntegerFieldElement#BigIntegerFieldElement(Field, BigInteger)}.
      */
     @Test
-    public void testFieldElementBigInteger() {
+    void testFieldElementBigInteger() {
         assertThat(new BigIntegerFieldElement(ed25519Field, BigInteger.ZERO).bi, is(BigInteger.ZERO));
         assertThat(new BigIntegerFieldElement(ed25519Field, BigInteger.ONE).bi, is(BigInteger.ONE));
         assertThat(new BigIntegerFieldElement(ed25519Field, BigInteger.valueOf(2)).bi, is(BigInteger.valueOf(2)));
@@ -79,7 +79,7 @@ public class BigIntegerFieldElementTest extends AbstractFieldElementTest {
      * Test method for {@link FieldElement#toByteArray()}.
      */
     @Test
-    public void testToByteArray() {
+    void testToByteArray() {
         byte[] zero = ZERO.toByteArray();
         assertThat(zero.length, is(equalTo(BYTES_ZERO.length)));
         assertThat(zero, is(equalTo(BYTES_ZERO)));
@@ -109,7 +109,7 @@ public class BigIntegerFieldElementTest extends AbstractFieldElementTest {
      * Test method for {@link FieldElement#equals(Object)}.
      */
     @Test
-    public void testEqualsObject() {
+    void testEqualsObject() {
         assertThat(new BigIntegerFieldElement(ed25519Field, BigInteger.ZERO), is(equalTo(ZERO)));
         assertThat(
                 new BigIntegerFieldElement(ed25519Field, BigInteger.valueOf(1000)),

--- a/src/test/java/net/i2p/crypto/eddsa/math/bigint/BigIntegerScalarOpsTest.java
+++ b/src/test/java/net/i2p/crypto/eddsa/math/bigint/BigIntegerScalarOpsTest.java
@@ -11,8 +11,8 @@
  */
 package net.i2p.crypto.eddsa.math.bigint;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.math.BigInteger;
 import net.i2p.crypto.eddsa.Utils;
@@ -20,13 +20,13 @@ import net.i2p.crypto.eddsa.math.Field;
 import net.i2p.crypto.eddsa.math.ScalarOps;
 import net.i2p.crypto.eddsa.spec.EdDSANamedCurveSpec;
 import net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author str4d
  *
  */
-public class BigIntegerScalarOpsTest {
+class BigIntegerScalarOpsTest {
 
     static final EdDSANamedCurveSpec ed25519 = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
     static final Field ed25519Field = ed25519.getCurve().getField();
@@ -35,7 +35,7 @@ public class BigIntegerScalarOpsTest {
      * Test method for {@link BigIntegerScalarOps#reduce(byte[])}.
      */
     @Test
-    public void testReduce() {
+    void testReduce() {
         ScalarOps sc = new BigIntegerScalarOps(ed25519Field, new BigInteger("5"));
         assertThat(
                 sc.reduce(new byte[] {7}),
@@ -56,7 +56,7 @@ public class BigIntegerScalarOpsTest {
      * Test method for {@link BigIntegerScalarOps#multiplyAndAdd(byte[], byte[], byte[])}.
      */
     @Test
-    public void testMultiplyAndAdd() {
+    void testMultiplyAndAdd() {
         ScalarOps sc = new BigIntegerScalarOps(ed25519Field, new BigInteger("5"));
         assertThat(
                 sc.multiplyAndAdd(new byte[] {7}, new byte[] {2}, new byte[] {5}),

--- a/src/test/java/net/i2p/crypto/eddsa/math/ed25519/Ed25519FieldElementTest.java
+++ b/src/test/java/net/i2p/crypto/eddsa/math/ed25519/Ed25519FieldElementTest.java
@@ -11,15 +11,18 @@
  */
 package net.i2p.crypto.eddsa.math.ed25519;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.math.BigInteger;
 import net.i2p.crypto.eddsa.math.*;
-import org.hamcrest.core.*;
-import org.junit.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests rely on the BigInteger class.
  */
-public class Ed25519FieldElementTest extends AbstractFieldElementTest {
+class Ed25519FieldElementTest extends AbstractFieldElementTest {
 
     protected FieldElement getRandomFieldElement() {
         return MathUtils.getRandomFieldElement();
@@ -40,21 +43,25 @@ public class Ed25519FieldElementTest extends AbstractFieldElementTest {
     // region constructor
 
     @Test
-    public void canConstructFieldElementFromArrayWithCorrectLength() {
+    void canConstructFieldElementFromArrayWithCorrectLength() {
         // Assert:
         new Ed25519FieldElement(MathUtils.getField(), new int[10]);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void cannotConstructFieldElementFromArrayWithIncorrectLength() {
-        // Assert:
-        new Ed25519FieldElement(MathUtils.getField(), new int[9]);
+    @Test
+    void cannotConstructFieldElementFromArrayWithIncorrectLength() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            // Assert:
+            new Ed25519FieldElement(MathUtils.getField(), new int[9]);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void cannotConstructFieldElementWithoutField() {
-        // Assert:
-        new Ed25519FieldElement(null, new int[9]);
+    @Test
+    void cannotConstructFieldElementWithoutField() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            // Assert:
+            new Ed25519FieldElement(null, new int[9]);
+        });
     }
 
     // endregion
@@ -76,7 +83,7 @@ public class Ed25519FieldElementTest extends AbstractFieldElementTest {
     // region toString
 
     @Test
-    public void toStringReturnsCorrectRepresentation() {
+    void toStringReturnsCorrectRepresentation() {
         // Arrange:
         final byte[] bytes = new byte[32];
         for (int i = 0; i < 32; i++) {
@@ -94,7 +101,7 @@ public class Ed25519FieldElementTest extends AbstractFieldElementTest {
         builder.append("]");
 
         // Assert:
-        Assert.assertThat(fAsString, IsEqual.equalTo(builder.toString()));
+        assertThat(fAsString, equalTo(builder.toString()));
     }
 
     // endregion

--- a/src/test/java/net/i2p/crypto/eddsa/math/ed25519/Ed25519LittleEndianEncodingTest.java
+++ b/src/test/java/net/i2p/crypto/eddsa/math/ed25519/Ed25519LittleEndianEncodingTest.java
@@ -11,21 +11,23 @@
  */
 package net.i2p.crypto.eddsa.math.ed25519;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
 import java.math.BigInteger;
 import java.security.SecureRandom;
 import net.i2p.crypto.eddsa.math.*;
-import org.hamcrest.core.IsEqual;
-import org.junit.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests rely on the BigInteger class.
  */
-public class Ed25519LittleEndianEncodingTest {
+class Ed25519LittleEndianEncodingTest {
 
     private static final SecureRandom random = new SecureRandom();
 
     @Test
-    public void encodeReturnsCorrectByteArrayForSimpleFieldElements() {
+    void encodeReturnsCorrectByteArrayForSimpleFieldElements() {
         // Arrange:
         final int[] t1 = new int[10];
         final int[] t2 = new int[10];
@@ -38,12 +40,12 @@ public class Ed25519LittleEndianEncodingTest {
         final byte[] bytes2 = MathUtils.getField().getEncoding().encode(fieldElement2);
 
         // Assert:
-        Assert.assertThat(bytes1, IsEqual.equalTo(MathUtils.toByteArray(BigInteger.ZERO)));
-        Assert.assertThat(bytes2, IsEqual.equalTo(MathUtils.toByteArray(BigInteger.ONE)));
+        assertThat(bytes1, equalTo(MathUtils.toByteArray(BigInteger.ZERO)));
+        assertThat(bytes2, equalTo(MathUtils.toByteArray(BigInteger.ONE)));
     }
 
     @Test
-    public void encodeReturnsCorrectByteArray() {
+    void encodeReturnsCorrectByteArray() {
         for (int i = 0; i < 10000; i++) {
             // Arrange:
             final int[] t = new int[10];
@@ -57,12 +59,12 @@ public class Ed25519LittleEndianEncodingTest {
             final byte[] bytes = MathUtils.getField().getEncoding().encode(fieldElement1);
 
             // Assert:
-            Assert.assertThat(bytes, IsEqual.equalTo(MathUtils.toByteArray(b.mod(MathUtils.getQ()))));
+            assertThat(bytes, equalTo(MathUtils.toByteArray(b.mod(MathUtils.getQ()))));
         }
     }
 
     @Test
-    public void decodeReturnsCorrectFieldElementForSimpleByteArrays() {
+    void decodeReturnsCorrectFieldElementForSimpleByteArrays() {
         // Arrange:
         final byte[] bytes1 = new byte[32];
         final byte[] bytes2 = new byte[32];
@@ -77,12 +79,12 @@ public class Ed25519LittleEndianEncodingTest {
         final BigInteger b2 = MathUtils.toBigInteger(f2.t);
 
         // Assert:
-        Assert.assertThat(b1, IsEqual.equalTo(BigInteger.ZERO));
-        Assert.assertThat(b2, IsEqual.equalTo(BigInteger.ONE));
+        assertThat(b1, equalTo(BigInteger.ZERO));
+        assertThat(b2, equalTo(BigInteger.ONE));
     }
 
     @Test
-    public void decodeReturnsCorrectFieldElement() {
+    void decodeReturnsCorrectFieldElement() {
         for (int i = 0; i < 10000; i++) {
             // Arrange:
             final byte[] bytes = new byte[32];
@@ -96,12 +98,12 @@ public class Ed25519LittleEndianEncodingTest {
             final BigInteger b2 = MathUtils.toBigInteger(f.t).mod(MathUtils.getQ());
 
             // Assert:
-            Assert.assertThat(b2, IsEqual.equalTo(b1));
+            assertThat(b2, equalTo(b1));
         }
     }
 
     @Test
-    public void isNegativeReturnsCorrectResult() {
+    void isNegativeReturnsCorrectResult() {
         for (int i = 0; i < 10000; i++) {
             // Arrange:
             final int[] t = new int[10];
@@ -115,7 +117,7 @@ public class Ed25519LittleEndianEncodingTest {
             final FieldElement f = new Ed25519FieldElement(MathUtils.getField(), t);
 
             // Assert:
-            Assert.assertThat(MathUtils.getField().getEncoding().isNegative(f), IsEqual.equalTo(isNegative));
+            assertThat(MathUtils.getField().getEncoding().isNegative(f), equalTo(isNegative));
         }
     }
 }

--- a/src/test/java/net/i2p/crypto/eddsa/math/ed25519/Ed25519ScalarOpsTest.java
+++ b/src/test/java/net/i2p/crypto/eddsa/math/ed25519/Ed25519ScalarOpsTest.java
@@ -11,22 +11,21 @@
  */
 package net.i2p.crypto.eddsa.math.ed25519;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.math.BigInteger;
 import net.i2p.crypto.eddsa.Utils;
 import net.i2p.crypto.eddsa.math.*;
-import org.hamcrest.core.IsEqual;
-import org.junit.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author str4d
  * Additional tests by the NEM project team.
  *
  */
-public class Ed25519ScalarOpsTest {
+class Ed25519ScalarOpsTest {
 
     private static final Ed25519ScalarOps scalarOps = new Ed25519ScalarOps();
 
@@ -34,7 +33,7 @@ public class Ed25519ScalarOpsTest {
      * Test method for {@link net.i2p.crypto.eddsa.math.bigint.BigIntegerScalarOps#reduce(byte[])}.
      */
     @Test
-    public void testReduce() {
+    void testReduce() {
         // Example from test case 1
         byte[] r = Utils.hexToBytes(
                 "b6b19cd8e0426f5983fa112d89a143aa97dab8bc5deb8d5b6253c928b65272f4044098c2a990039cde5b6a4818df0bfb6e40dc5dee54248032962323e701352d");
@@ -44,7 +43,7 @@ public class Ed25519ScalarOpsTest {
     }
 
     @Test
-    public void reduceReturnsExpectedResult() {
+    void reduceReturnsExpectedResult() {
         for (int i = 0; i < 1000; i++) {
             // Arrange:
             final byte[] bytes = MathUtils.getRandomByteArray(64);
@@ -54,10 +53,9 @@ public class Ed25519ScalarOpsTest {
             final byte[] reduced2 = MathUtils.reduceModGroupOrder(bytes);
 
             // Assert:
-            Assert.assertThat(
-                    MathUtils.toBigInteger(reduced1).compareTo(MathUtils.getGroupOrder()), IsEqual.equalTo(-1));
-            Assert.assertThat(MathUtils.toBigInteger(reduced1).compareTo(new BigInteger("-1")), IsEqual.equalTo(1));
-            Assert.assertThat(reduced1, IsEqual.equalTo(reduced2));
+            assertThat(MathUtils.toBigInteger(reduced1).compareTo(MathUtils.getGroupOrder()), equalTo(-1));
+            assertThat(MathUtils.toBigInteger(reduced1).compareTo(new BigInteger("-1")), equalTo(1));
+            assertThat(reduced1, equalTo(reduced2));
         }
     }
 
@@ -65,7 +63,7 @@ public class Ed25519ScalarOpsTest {
      * Test method for {@link net.i2p.crypto.eddsa.math.bigint.BigIntegerScalarOps#multiplyAndAdd(byte[], byte[], byte[])}.
      */
     @Test
-    public void testMultiplyAndAdd() {
+    void testMultiplyAndAdd() {
         // Example from test case 1
         byte[] h = Utils.hexToBytes("86eabc8e4c96193d290504e7c600df6cf8d8256131ec2c138a3e7e162e525404");
         byte[] a = Utils.hexToBytes("307c83864f2833cb427a2ef1c00a013cfdff2768d980c0a3a520f006904de94f");
@@ -75,7 +73,7 @@ public class Ed25519ScalarOpsTest {
     }
 
     @Test
-    public void multiplyAndAddReturnsExpectedResult() {
+    void multiplyAndAddReturnsExpectedResult() {
         for (int i = 0; i < 1000; i++) {
             // Arrange:
             final byte[] bytes1 = MathUtils.getRandomByteArray(32);
@@ -87,10 +85,9 @@ public class Ed25519ScalarOpsTest {
             final byte[] result2 = MathUtils.multiplyAndAddModGroupOrder(bytes1, bytes2, bytes3);
 
             // Assert:
-            Assert.assertThat(
-                    MathUtils.toBigInteger(result1).compareTo(MathUtils.getGroupOrder()), IsEqual.equalTo(-1));
-            Assert.assertThat(MathUtils.toBigInteger(result1).compareTo(new BigInteger("-1")), IsEqual.equalTo(1));
-            Assert.assertThat(result1, IsEqual.equalTo(result2));
+            assertThat(MathUtils.toBigInteger(result1).compareTo(MathUtils.getGroupOrder()), equalTo(-1));
+            assertThat(MathUtils.toBigInteger(result1).compareTo(new BigInteger("-1")), equalTo(1));
+            assertThat(result1, equalTo(result2));
         }
     }
 }

--- a/src/test/java/net/i2p/crypto/eddsa/spec/EdDSANamedCurveTableTest.java
+++ b/src/test/java/net/i2p/crypto/eddsa/spec/EdDSANamedCurveTableTest.java
@@ -13,21 +13,21 @@ package net.i2p.crypto.eddsa.spec;
 
 import static net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable.ED_25519;
 import static net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable.ED_25519_CURVE_SPEC;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author str4d
  *
  */
-public class EdDSANamedCurveTableTest {
+class EdDSANamedCurveTableTest {
     /**
      * Ensure curve names are case-inspecific
      */
     @Test
-    public void curveNamesAreCaseInspecific() {
+    void curveNamesAreCaseInspecific() {
         EdDSANamedCurveSpec mixed = EdDSANamedCurveTable.getByName("Ed25519");
         EdDSANamedCurveSpec lower = EdDSANamedCurveTable.getByName("ed25519");
         EdDSANamedCurveSpec upper = EdDSANamedCurveTable.getByName("ED25519");
@@ -37,7 +37,7 @@ public class EdDSANamedCurveTableTest {
     }
 
     @Test
-    public void testConstants() {
+    void testConstants() {
         EdDSANamedCurveSpec spec = EdDSANamedCurveTable.getByName(ED_25519);
         assertThat("Named curve and constant should match", spec, is(equalTo(ED_25519_CURVE_SPEC)));
     }

--- a/src/test/java/net/i2p/crypto/eddsa/spec/EdDSAPrivateKeySpecTest.java
+++ b/src/test/java/net/i2p/crypto/eddsa/spec/EdDSAPrivateKeySpecTest.java
@@ -11,19 +11,19 @@
  */
 package net.i2p.crypto.eddsa.spec;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import net.i2p.crypto.eddsa.Utils;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author str4d
  *
  */
-public class EdDSAPrivateKeySpecTest {
+class EdDSAPrivateKeySpecTest {
     static final byte[] ZERO_SEED =
             Utils.hexToBytes("0000000000000000000000000000000000000000000000000000000000000000");
     static final byte[] ZERO_H = Utils.hexToBytes(
@@ -32,14 +32,11 @@ public class EdDSAPrivateKeySpecTest {
 
     static final EdDSANamedCurveSpec ed25519 = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
     /**
      * Test method for {@link EdDSAPrivateKeySpec#EdDSAPrivateKeySpec(byte[], EdDSAParameterSpec)}.
      */
     @Test
-    public void testEdDSAPrivateKeySpecFromSeed() {
+    void testEdDSAPrivateKeySpecFromSeed() {
         EdDSAPrivateKeySpec key = new EdDSAPrivateKeySpec(ZERO_SEED, ed25519);
         assertThat(key.getSeed(), is(equalTo(ZERO_SEED)));
         assertThat(key.getH(), is(equalTo(ZERO_H)));
@@ -47,17 +44,17 @@ public class EdDSAPrivateKeySpecTest {
     }
 
     @Test
-    public void incorrectSeedLengthThrows() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("seed length is wrong");
-        EdDSAPrivateKeySpec key = new EdDSAPrivateKeySpec(new byte[2], ed25519);
+    void incorrectSeedLengthThrows() {
+        IllegalArgumentException exception =
+                assertThrows(IllegalArgumentException.class, () -> new EdDSAPrivateKeySpec(new byte[2], ed25519));
+        assertTrue(exception.getMessage().contains("seed length is wrong"));
     }
 
     /**
      * Test method for {@link EdDSAPrivateKeySpec#EdDSAPrivateKeySpec(EdDSAParameterSpec, byte[])}.
      */
     @Test
-    public void testEdDSAPrivateKeySpecFromH() {
+    void testEdDSAPrivateKeySpecFromH() {
         EdDSAPrivateKeySpec key = new EdDSAPrivateKeySpec(ed25519, ZERO_H);
         assertThat(key.getSeed(), is(nullValue()));
         assertThat(key.getH(), is(equalTo(ZERO_H)));
@@ -65,9 +62,9 @@ public class EdDSAPrivateKeySpecTest {
     }
 
     @Test
-    public void incorrectHashLengthThrows() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("hash length is wrong");
-        EdDSAPrivateKeySpec key = new EdDSAPrivateKeySpec(ed25519, new byte[2]);
+    void incorrectHashLengthThrows() {
+        IllegalArgumentException exception =
+                assertThrows(IllegalArgumentException.class, () -> new EdDSAPrivateKeySpec(ed25519, new byte[2]));
+        assertTrue(exception.getMessage().contains("hash length is wrong"));
     }
 }


### PR DESCRIPTION
This PR aims to migrate all tests to JUnit5. Changes include:

* Migrate annotations and imports
* Migrate assertions
* Remove public visibility for test classes and methods
* Minor clean up

There are 3 exceptions where a migration was not possible as the tests rely on `Rule` implementations that have not (yet) been migrated to JUnit5:

* `EddsaTest` using `RealJenkinsRule`
* `EddsaTestWithFreestyleProject` using `RealJenkinsRule`
* `FIPSComplianceCheckTest` using `RealJenkinsRule`

I am well aware that this is a quite large changeset however I hope that there is still interest in this PR and it will be reviewed.
If there are any questions, please do not hesitate to ping me.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
